### PR TITLE
Add local server setup and fix README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ git clone https://github.com/matsu-essence/g-cert-master-public.git
 cd g-cert-master-public
 npm install
 npm start
+
+```
+
+ブラウザで [http://localhost:3000](http://localhost:3000) を開いてアプリを確認してください。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "g-cert-master-public",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "g-cert-master-public",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "g-cert-master-public",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,41 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = process.env.PORT || 3000;
+const baseDir = __dirname;
+
+const server = http.createServer((req, res) => {
+  const safeSuffix = path.normalize(req.url).replace(/^\/+/, '');
+  const fileLoc = path.join(baseDir, safeSuffix || 'index.html');
+
+  fs.readFile(fileLoc, (err, data) => {
+    if (err) {
+      res.statusCode = 404;
+      res.end('Not Found');
+      return;
+    }
+
+    const ext = path.extname(fileLoc).toLowerCase();
+    const contentType = {
+      '.html': 'text/html',
+      '.js': 'text/javascript',
+      '.css': 'text/css',
+      '.json': 'application/json',
+      '.png': 'image/png',
+      '.jpg': 'image/jpeg',
+      '.jpeg': 'image/jpeg',
+      '.gif': 'image/gif',
+      '.svg': 'image/svg+xml',
+      '.ico': 'image/x-icon'
+    }[ext] || 'application/octet-stream';
+
+    res.statusCode = 200;
+    res.setHeader('Content-Type', contentType);
+    res.end(data);
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- add simple Node.js static server and npm scripts to run it
- document local run steps in README

## Testing
- `npm install`
- `npm start`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6893053f9090832fa732e18fbeafcfa4